### PR TITLE
Switch image share to use active_time for showing speed/pace

### DIFF
--- a/apps/api/src/modules/health-activities/health-activities.service.ts
+++ b/apps/api/src/modules/health-activities/health-activities.service.ts
@@ -305,10 +305,9 @@ export class HealthActivitiesService {
 
   async getHealthActivityStatsFormatted(healthActivity: HealthActivity) {
     const unitSystem = healthActivity.user.unit_system
-    const durationInSeconds = differenceInSeconds(
-      healthActivity.end_time,
-      healthActivity.start_time
-    )
+    const durationInSeconds =
+      healthActivity.active_time ||
+      differenceInSeconds(healthActivity.end_time, healthActivity.start_time)
     const stats: ShareableImageStat[] = []
 
     // DISTANCE


### PR DESCRIPTION
# Pull Request

## Description

- Switch image sharer to use `active_time` rather than difference in seconds between start / end time. This should account for runners pausing their run. 

Fixes # (YouTrack issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and/or existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
- [x] I have checked the associated YouTrack ticket and validated my work against the ticket requirements

## Does this introduce new NPM dependencies?

If yes, please describe which dependencies have been changed or added.

- [ ] Yes
- [x] No
