### PR TITLE
fix: fetch fitbit summary on user ping

### DIFF
--- a/apps/api/src/events/index.ts
+++ b/apps/api/src/events/index.ts
@@ -5,5 +5,6 @@ export enum Events {
   LEAGUE_JOINED = 'league.joined',
   USER_NEW_FOLLOWER = 'user.new_follower',
   DAILY_GOAL_REACHED = 'daily_goal.reached',
-  USER_ACTIVE_MINUTES_WEEK_INCREMENTED = 'user.active_minutes_week_incremented'
+  USER_ACTIVE_MINUTES_WEEK_INCREMENTED = 'user.active_minutes_week_incremented',
+  USER_PING = 'user.ping'
 }

--- a/apps/api/src/modules/users/listeners/FitbitUserPing.ts
+++ b/apps/api/src/modules/users/listeners/FitbitUserPing.ts
@@ -1,0 +1,53 @@
+import { Injectable } from '@nestjs/common'
+import { OnEvent } from '@nestjs/event-emitter'
+import { InjectRepository } from '@nestjs/typeorm'
+import { Repository } from 'typeorm'
+import {
+  FeedItemCategory,
+  FeedItemType
+} from '../../feed-items/feed-items.constants'
+import { FeedItemsService } from '../../feed-items/feed-items.service'
+import { User } from '../entities/user.entity'
+import { Events } from '../../../../src/events'
+import { NotificationsService } from '../../notifications/notifications.service'
+import { NotificationAction } from '../../notifications/notifications.constants'
+import { AuthenticatedUser } from '../../../models'
+import { tryAndCatch } from '../../../helpers/tryAndCatch'
+import { FitbitService } from '../../providers/providers/fitbit/fitbit.service'
+import { LifestyleGoalActivityDTO } from '../../providers/types/fitbit'
+
+@Injectable()
+export class FitbitUserListener {
+  constructor(private fitbit: FitbitService) {}
+  @OnEvent(Events.USER_PING)
+  async onUserPingEvent(payload: AuthenticatedUser) {
+    const [token, tokenErr] = await tryAndCatch(
+      this.fitbit.getFreshFitbitToken(payload.id)
+    )
+
+    tokenErr && console.error(tokenErr.message)
+
+    // Do not continue if there's no token available
+    if (tokenErr) {
+      return
+    }
+
+    const [summaryResult, summaryResultErr] = await tryAndCatch(
+      this.fitbit.fetchActivitySummaryByDay(token, new Date().toUTCString())
+    )
+
+    // Do not continue if there's an error
+    if (summaryResultErr) {
+      return
+    }
+
+    const lifestyleStats: LifestyleGoalActivityDTO = {
+      steps: summaryResult.summary.steps || 0,
+      floors_climbed: summaryResult.summary.floors || 0,
+      sleep_hours: 0,
+      water_litres: 0,
+      mindfulness: 0
+    }
+    await this.fitbit.prcoessDailyGoalsHistory(payload.id, lifestyleStats)
+  }
+}

--- a/apps/api/src/modules/users/users.controller.ts
+++ b/apps/api/src/modules/users/users.controller.ts
@@ -53,6 +53,8 @@ import { ConfigService } from '@nestjs/config'
 import { UserJobDto } from './dto/user-job.dto'
 import { CreateFcmTokenDto } from './dto/create-fcm-token.dto'
 import { DeleteFcmTokenDto } from './dto/delete-fcm-token.dto'
+import { Events } from '../../events'
+import { EventEmitter2 } from '@nestjs/event-emitter'
 
 @Controller()
 @ApiBaseResponses()
@@ -60,7 +62,8 @@ export class UsersController {
   constructor(
     private readonly usersService: UsersService,
     private readonly userRolesService: UserRolesService,
-    private readonly configService: ConfigService
+    private readonly configService: ConfigService,
+    private eventEmitter: EventEmitter2
   ) {}
 
   // User endpoints (requires JWT)
@@ -176,7 +179,8 @@ export class UsersController {
   @Put('me/ping')
   @ApiTags('me')
   @UpdateResponse()
-  pingUser(@AuthUser() user: AuthenticatedUser) {
+  async pingUser(@AuthUser() user: AuthenticatedUser) {
+    await this.eventEmitter.emitAsync(Events.USER_PING, user)
     return this.usersService.ping(user.id)
   }
 

--- a/apps/api/src/modules/users/users.module.ts
+++ b/apps/api/src/modules/users/users.module.ts
@@ -18,6 +18,8 @@ import { UserActiveMinutesIncrementedListener } from './listeners/UserActiveMinu
 import { NotificationsModule } from '../notifications/notifications.module'
 import { GoalsEntriesModule } from '../goals-entries/goals-entries.module'
 import { RefreshToken } from '../auth/entities/auth.entity'
+import { FitbitUserListener } from './listeners/FitbitUserPing'
+import { ProvidersModule } from '../providers/providers.module'
 
 @Module({
   imports: [
@@ -42,7 +44,8 @@ import { RefreshToken } from '../auth/entities/auth.entity'
           signOptions: { expiresIn: '1h' }
         }
       }
-    })
+    }),
+    ProvidersModule
   ],
   controllers: [UsersController],
   providers: [
@@ -50,7 +53,8 @@ import { RefreshToken } from '../auth/entities/auth.entity'
     ConfigService,
     UserPointsIncrementedListener,
     NewFollowerListener,
-    UserActiveMinutesIncrementedListener
+    UserActiveMinutesIncrementedListener,
+    FitbitUserListener
   ],
   exports: [TypeOrmModule.forFeature([User]), UsersService]
 })


### PR DESCRIPTION
Signed-off-by: Jordan Hall <Jordan@libertyware.co.uk>

# Pull Request

## Description

> Fitbit summary doesn't always get updated on webhooks. As a result, we need to fetch the user daily summary when the user is pinged (when app goes into the foreground)

Fixes #FIT-242

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] New and/or existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
- [x] I have checked the associated YouTrack ticket and validated my work against the ticket requirements

## Does this introduce new NPM dependencies?

If yes, please describe which dependencies have been changed or added.

- [ ] Yes
- [x] No
