### PR TITLE
Feature/mobile/203

### DIFF
--- a/apps/api/src/modules/leagues/dto/is-private-only.dto.ts
+++ b/apps/api/src/modules/leagues/dto/is-private-only.dto.ts
@@ -1,0 +1,15 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { Transform } from "class-transformer";
+import { IsOptional } from "class-validator";
+
+export class LeaguesIsPrivateOnlyDto {
+    @ApiProperty({
+      required: false,
+      nullable: true
+    })
+    @IsOptional()
+    @Transform(({value}) =>
+      value === 'true'
+    )
+    isPrivateOnly?: boolean
+  }

--- a/apps/api/src/modules/leagues/dto/search-league.dto.ts
+++ b/apps/api/src/modules/leagues/dto/search-league.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger'
-import { IsNotEmpty } from 'class-validator'
+import { IsNotEmpty, IsOptional } from 'class-validator'
 
 export class SearchLeagueDto {
   @ApiProperty()

--- a/apps/api/src/modules/leagues/leagues.controller.ts
+++ b/apps/api/src/modules/leagues/leagues.controller.ts
@@ -47,6 +47,7 @@ import { SearchUserForLeaguesDto } from '../users/dto/search-user.dto'
 import { ConfigService } from '@nestjs/config'
 import { LeagueJobDto } from './dto/league-job.dto'
 import { Public } from '../../decorators/public.decorator'
+import { LeaguesIsPrivateOnlyDto } from './dto/is-private-only.dto'
 
 @ApiTags('leagues')
 @ApiBaseResponses()
@@ -163,14 +164,16 @@ export class LeaguesController {
   @PaginationBody()
   findAll(
     @User() authUser: AuthenticatedUser,
-    @Pagination() pagination: PaginationQuery
+    @Pagination() pagination: PaginationQuery,
+    @Query() isPrivateQuery: LeaguesIsPrivateOnlyDto,
   ) {
     if (authUser.isSuperAdmin()) {
       return this.leaguesService.findAll({}, pagination)
     } else {
       return this.leaguesService.findAllNotParticipating(
         authUser.id,
-        pagination
+        pagination,
+        isPrivateQuery.isPrivateOnly,
       )
     }
   }
@@ -209,12 +212,14 @@ export class LeaguesController {
   search(
     @Query() query: SearchLeagueDto,
     @User() user: AuthenticatedUser,
-    @Pagination() pagination: PaginationQuery
+    @Pagination() pagination: PaginationQuery,
+    @Query() isPrivateQuery: LeaguesIsPrivateOnlyDto,
   ) {
     return this.leaguesService.searchManyAccessibleToUser(
       query.q,
       user.id,
-      pagination
+      pagination,
+      isPrivateQuery.isPrivateOnly,
     )
   }
 

--- a/apps/api/src/modules/leagues/leagues.service.ts
+++ b/apps/api/src/modules/leagues/leagues.service.ts
@@ -208,7 +208,8 @@ export class LeaguesService {
 
   async findAllNotParticipating(
     userId: string,
-    { limit = 10, page = 0 }: PaginationOptionsInterface
+    { limit = 10, page = 0 }: PaginationOptionsInterface,
+    isPrivateOnly = false,
   ) {
     // Use a subquery inside a where statement to determine
     // leagues that the user does not yet belong to.
@@ -218,7 +219,7 @@ export class LeaguesService {
       .innerJoin('league.users', 'user')
       .where('user.id = :userId', { userId })
 
-    const query = this.queryFindAccessibleToUser(userId)
+    const query = this.queryFindAccessibleToUser(userId, isPrivateOnly)
       .andWhere(`league.id NOT IN (${where.getQuery()})`)
       .take(limit)
       .skip(page * limit)
@@ -330,9 +331,10 @@ export class LeaguesService {
   async searchManyAccessibleToUser(
     keyword: string,
     userId: string,
-    { limit = 10, page = 0 }: PaginationOptionsInterface
+    { limit = 10, page = 0 }: PaginationOptionsInterface,
+    isPrivateOnly = false
   ) {
-    const query = this.queryFindAccessibleToUser(userId)
+    const query = this.queryFindAccessibleToUser(userId, isPrivateOnly)
       .andWhere(
         '(league.name ILIKE :keyword OR league.description ILIKE :keyword)',
         { keyword: `%${keyword}%` }
@@ -412,7 +414,7 @@ export class LeaguesService {
    * @param userId
    * @returns
    */
-  queryFindAccessibleToUser(userId: string) {
+  queryFindAccessibleToUser(userId: string, isPrivateOnly = false) {
     const rankQb = this.leaderboardEntryRepository
       .createQueryBuilder('entry')
       .select(
@@ -457,10 +459,9 @@ export class LeaguesService {
         .where(
           new Brackets((qb) => {
             // The league is public
+            const checkedQb = isPrivateOnly ? qb : qb.where('league.access = :accessPublic')
             return (
-              qb
-                .where('league.access = :accessPublic')
-
+              checkedQb
                 // The league is private & owned by the user
                 .orWhere(
                   '(league.access = :accessPrivate AND owner.id = :userId)'

--- a/apps/api/src/modules/rewards/dto/reward-filters.dto.ts
+++ b/apps/api/src/modules/rewards/dto/reward-filters.dto.ts
@@ -1,4 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger'
+import { Transform } from 'class-transformer'
 import { IsBoolean, IsInt, IsNumberString, IsOptional } from 'class-validator'
 
 export class RewardFiltersDto {
@@ -22,6 +23,16 @@ export class RewardFiltersDto {
   })
   @IsOptional()
   available?: boolean = false
+
+  @ApiProperty({
+    required: false,
+    nullable: true
+  })
+  @IsOptional()
+  @Transform(({value}) =>
+    value === 'true'
+  )
+  isPrivateOnly?: boolean = false
 }
 
 export class RewardGlobalFilterDto {

--- a/apps/api/src/modules/rewards/rewards.controller.ts
+++ b/apps/api/src/modules/rewards/rewards.controller.ts
@@ -76,16 +76,15 @@ export class RewardsController {
     @User() authUser: AuthenticatedUser,
     @Pagination() pagination: PaginationQuery,
     @Query() appFilters: RewardFiltersDto,
-    @Query() dashboardFilters: RewardGlobalFilterDto
+    @Query() dashboardFilters: RewardGlobalFilterDto,
   ) {
     if (authUser.isSuperAdmin()) {
       return this.rewardsService.findAll(pagination, dashboardFilters)
     }
-
     return this.rewardsService.findManyAccessibleToUser(
       authUser.id,
       pagination,
-      appFilters
+      appFilters,
     )
   }
 

--- a/apps/api/src/modules/rewards/rewards.service.ts
+++ b/apps/api/src/modules/rewards/rewards.service.ts
@@ -33,7 +33,8 @@ type ParentIds = {
 
 type QueryOptions = {
   checkExpiry?: boolean
-  checkAvailability?: boolean
+  checkAvailability?: boolean,
+  isPrivateOnly?: boolean,
 }
 
 type PublicPageReward = {
@@ -103,9 +104,13 @@ export class RewardsService {
   async findManyAccessibleToUser(
     userId: string,
     { limit = 10, page = 0 }: PaginationOptionsInterface,
-    filters: RewardFiltersDto
+    filters: RewardFiltersDto,
   ) {
-    let query = this.queryFindAccessibleToUser(userId)
+    let query = this.queryFindAccessibleToUser(userId, {
+      isPrivateOnly: filters.isPrivateOnly,
+      checkExpiry: true,
+      checkAvailability: true,
+    })
 
     // Where rewards are not available (not enough points) and not redeemed
     if (filters.locked) {
@@ -259,7 +264,8 @@ export class RewardsService {
     userId: string,
     options: QueryOptions = {
       checkExpiry: true,
-      checkAvailability: true
+      checkAvailability: true,
+      isPrivateOnly: false,
     }
   ) {
     let query = this.rewardsRepository
@@ -285,11 +291,10 @@ export class RewardsService {
 
       .where(
         new Brackets((qb) => {
-          // The league is public
+          // The reward is public
+          const checkedQb = options.isPrivateOnly ? qb : qb.where('reward.access = :accessPublic')
           return (
-            qb
-              .where('reward.access = :accessPublic')
-
+            checkedQb
               // The user belongs to the team that the league belongs to
               .orWhere(
                 `(reward.access = :accessTeam AND teamUser.id = :userId)`

--- a/apps/mobile/src/hooks/api/leagues/useLeagues.ts
+++ b/apps/mobile/src/hooks/api/leagues/useLeagues.ts
@@ -4,19 +4,31 @@ import api from '@api';
 import {ListResponse} from '@fitlink/api-sdk/types';
 import {getNextPageParam} from 'utils/api';
 import {League} from '@fitlink/api/src/modules/leagues/entities/league.entity';
+import {useMe} from '@hooks';
 
 const limit = 25;
 
-const fetchLeagues = ({pageParam = 0}: {pageParam?: number | undefined}) =>
-  api.list<League>(`/leagues`, {
+const fetchLeagues = ({
+  pageParam = 0,
+  isPrivateOnly = false,
+}: {
+  pageParam?: number | undefined;
+  isPrivateOnly: boolean;
+}) =>
+  api.list<League>('/leagues', {
     page: pageParam,
     limit,
+    isPrivateOnly,
   });
 
 export function useLeagues() {
+  const {data: user} = useMe({
+    refetchOnMount: false,
+  });
+  const isPrivateOnly = Boolean(user?.teams.length);
   return useInfiniteQuery<ListResponse<League>, Error>(
     QueryKeys.Leagues,
-    ({pageParam}) => fetchLeagues({pageParam}),
+    ({pageParam}) => fetchLeagues({pageParam, isPrivateOnly}),
     {
       getNextPageParam: getNextPageParam(limit),
     },

--- a/apps/mobile/src/hooks/api/rewards/useRewards.ts
+++ b/apps/mobile/src/hooks/api/rewards/useRewards.ts
@@ -4,6 +4,7 @@ import api from '@api';
 import {ListResponse} from '@fitlink/api-sdk/types';
 import {getNextPageParam} from 'utils/api';
 import {RewardPublic} from '@fitlink/api/src/modules/rewards/entities/reward.entity';
+import {useMe} from '@hooks';
 
 export const REWARD_RESULTS_PER_PAGE = 10;
 
@@ -16,9 +17,11 @@ interface RewardsParams {
 const fetchRewards = ({
   pageParam = 0,
   params,
+  isPrivateOnly = false,
 }: {
   pageParam?: number | undefined;
   params: RewardsParams;
+  isPrivateOnly?: boolean;
 }) => {
   const searchParams = new URLSearchParams();
 
@@ -39,14 +42,19 @@ const fetchRewards = ({
     {
       page: pageParam,
       limit: REWARD_RESULTS_PER_PAGE,
+      isPrivateOnly,
     },
   );
 };
 
 export function useRewards(params: RewardsParams) {
+  const {data: user} = useMe({
+    refetchOnMount: false,
+  });
+  const isPrivateOnly = Boolean(user?.teams.length);
   return useInfiniteQuery<ListResponse<RewardPublic>, Error>(
-    [QueryKeys.Rewards, JSON.stringify(params)],
-    ({pageParam}) => fetchRewards({pageParam, params}),
+    [QueryKeys.Rewards, JSON.stringify(params), isPrivateOnly],
+    ({pageParam}) => fetchRewards({pageParam, params, isPrivateOnly}),
     {
       getNextPageParam: getNextPageParam(REWARD_RESULTS_PER_PAGE),
       keepPreviousData: true,


### PR DESCRIPTION
### api changes
Added isPrivateOnly query parameter for /leagues /leagues/search and /rewards calls
If the query parameter is true, result doesn't include public data (public leagues or rewards)

### mobile changes
if user has teams, calls for leagues and rewards are with isPrivateOnly=true