### PR TITLE
fix: leftjoin so we still get all the users for the league

### DIFF
--- a/apps/api/src/modules/leagues/leagues.service.ts
+++ b/apps/api/src/modules/leagues/leagues.service.ts
@@ -1685,7 +1685,7 @@ export class LeaguesService {
     const started = new Date()
     const leagues = await this.leaguesRepository
       .createQueryBuilder('league')
-      .innerJoinAndSelect('league.active_leaderboard', 'active_leaderboard')
+      .leftJoinAndSelect('league.active_leaderboard', 'active_leaderboard')
       .leftJoinAndSelect('league.users', 'users')
       .where('league.ends_at <= :date', { date: new Date() })
       .andWhere('active_leaderboard.completed = false')


### PR DESCRIPTION
They seem to be cases where users are in the league but not active leaderboard. So we need to return all league side for the users.